### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,11 +2,14 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   
 
+  
+
   def index
     @items = Item.includes(:user).order('created_at DESC')
   end
 
   def show
+    @item = Item.find(params[:id])
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,7 +8,7 @@ class Item < ApplicationRecord
   belongs_to :user
 
   has_one_attached :image
-  has_one :order_history
+  #has_one :order_history
 
 
   validates :image, :name, :description, :category_id, :status_id, :delivery_cost_id, :prefecture_id, :days_id, presence: true

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,7 +8,7 @@ class Item < ApplicationRecord
   belongs_to :user
 
   has_one_attached :image
-  #has_one :order_history
+  has_one :order_history
 
 
   validates :image, :name, :description, :category_id, :status_id, :delivery_cost_id, :prefecture_id, :days_id, presence: true

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,12 +130,12 @@
 
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" if item.image.attached? %>
 
           <%# if item.order_history != nil %>
-          <div class='sold-out'>
+          <%#div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
           <%# end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,67 +4,67 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
+      <%= image_tag @item.image ,class:"item-box-img" %>
+      <%# if @item.order_history != nil %>
+      <%#div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <%# end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
         ¥ 999,999,999
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.delivery_cost.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+  <% if user_signed_in? %>
+  <% if current_user.id == @item.user_id && @item.order_history.nil? %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
 
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
+　
+    <% elsif @item.order_history.present? %>
+    <% else %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% end%>
+  <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.delivery_cost.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.days.name %></td>
         </tr>
       </tbody>
     </table>
@@ -103,9 +103,8 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,7 +25,7 @@
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
   <% if user_signed_in? %>
-  <% if current_user.id == @item.user_id && @item.order_history.nil? %>
+  <% if current_user.id == @item.user_id %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -16,14 +16,14 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥<%= @item.price %>
       </span>
       <span class="item-postage">
         <%= @item.delivery_cost.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+
   <% if user_signed_in? %>
   <% if current_user.id == @item.user_id %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
@@ -31,7 +31,7 @@
     <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
 
 　
-    <% elsif @item.order_history.present? %>
+    <%# elsif @item.order_history.present? %>
     <% else %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <% end%>


### PR DESCRIPTION
# What
商品の詳細情報を表示できる画面を作成した

# Why
商品詳細表示機能を実装するため

■ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
[https://gyazo.com/d58582be159ac356527eb152afa2cd4d](url)
■ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
[https://gyazo.com/57a9332f1269027e06dd5ce211d4d49d](url)
■ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
未実装
■ログアウト状態で、商品詳細ページへ遷移した動画
[https://gyazo.com/466926b62281574931ac86d51fbdc1b3](url)